### PR TITLE
create symlinks

### DIFF
--- a/initial_setup.sh
+++ b/initial_setup.sh
@@ -5,6 +5,15 @@
 # Author: johnpneumann
 #
 set -e
+# Create our symlinks
+ln -s .bash_aliases ~/.bash_aliases
+ln -s .bash_profile ~/.bash_profile
+ln -s .bashrc ~/.bashrc
+ln -s .inputrc ~/.inputrc
+ln -s .profile ~/.profile
+ln -s .vim ~/.vim
+ln -s .vimrc ~/.vimrc
+ln -s iterm2_prefs ~/iterm2_prefs
 # Install xcode command line tools
 xcode-select --install
 # Install homebrew


### PR DESCRIPTION
resolves #12 

Can't create them with ansible because it's too recursive (symlink a file from within the playbook, which doesn't make sense, though we could move this out to some other location and do it there).
